### PR TITLE
Prevent junk entries with '/'

### DIFF
--- a/libsubfinder/helper/misc.go
+++ b/libsubfinder/helper/misc.go
@@ -87,7 +87,7 @@ func ExtractSubdomains(text, domain string) (urls []string) {
 //Validate returns valid subdomains found ending with target domain
 func Validate(domain string, strslice []string) (subdomains []string) {
 	for _, entry := range strslice {
-		if strings.HasSuffix(entry, "."+domain) {
+		if !strings.Contains(entry, "/") && strings.HasSuffix(entry, "."+domain) {
 			subdomains = append(subdomains, entry)
 		}
 	}


### PR DESCRIPTION
Hello,

I've added an extra step to prevent entries like:
```
www.easycounter.com/report/testnet.redacted.com
www.easycounter.com/report/testnet.redacted.com","title":"Testnet.redacted.com
```

from showing up.