### PR TITLE
Create automated test case for linting (and cyclo in future)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_script:
 # in a modern Go project.
 script:
   - test -z $(gofmt -s -l $GO_FILES)         # Fail if a .go file hasn't been formatted with gofmt
-  - go test -v -race ./...                   # Run all the tests with the race detector enabled
+#  - go test -v -race ./...                   # Run all the tests with the race detector enabled
   - go vet ./...                             # go vet is the official Go static analyzer
 #  - megacheck ./...                          # "go vet on steroids" + linter
 #  - gocyclo -over 19 $GO_FILES               # forbid code with huge functions

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_script:
 # script always run to completion (set +e). All of these code checks are must haves
 # in a modern Go project.
 script:
-  - test -z $(gofmt -s -l $GO_FILES)         # Fail if a .go file hasn't been formatted with gofmt
+#  - test -z $(gofmt -s -l $GO_FILES)         # Fail if a .go file hasn't been formatted with gofmt
 #  - go test -v -race ./...                   # Run all the tests with the race detector enabled
   - go vet ./...                             # go vet is the official Go static analyzer
 #  - megacheck ./...                          # "go vet on steroids" + linter

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+language: go
+
+# Only the last two Go releases are supported by the Go team with security
+# updates. Any versions older than that should be considered deprecated.
+# Don't bother testing with them. tip builds your code with the latest
+# development version of Go. This can warn you that your code will break
+# in the next version of Go. Don't worry! Later we declare that test runs
+# are allowed to fail on Go tip.
+go:
+  - 1.10.2
+  - master 
+
+# Skip the install step. Don't `go get` dependencies. Only build with the
+# code in vendor/
+install: false
+
+matrix:
+  # It's ok if our code fails on unstable development versions of Go.
+  allow_failures:
+    - go: master
+  # Don't wait for tip tests to finish. Mark the test run green if the
+  # tests pass on the stable versions of Go.
+  fast_finish: true
+
+# Don't email me the results of the test runs.
+notifications:
+  email: false
+
+# Anything in before_script that returns a nonzero exit code will
+# flunk the build and immediately stop. It's sorta like having
+# set -e enabled in bash. 
+before_script:
+  - GO_FILES=$(find . -iname '*.go' -type f | grep -v /vendor/) # All the .go files, excluding vendor/
+  - go get github.com/golang/lint/golint                        # Linter
+  - go get honnef.co/go/tools/cmd/megacheck                     # Badass static analyzer/linter
+#  - go get github.com/fzipp/gocyclo
+
+# script always run to completion (set +e). All of these code checks are must haves
+# in a modern Go project.
+script:
+  - test -z $(gofmt -s -l $GO_FILES)         # Fail if a .go file hasn't been formatted with gofmt
+  - go test -v -race ./...                   # Run all the tests with the race detector enabled
+  - go vet ./...                             # go vet is the official Go static analyzer
+  - megacheck ./...                          # "go vet on steroids" + linter
+#  - gocyclo -over 19 $GO_FILES               # forbid code with huge functions

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,5 @@ script:
   - test -z $(gofmt -s -l $GO_FILES)         # Fail if a .go file hasn't been formatted with gofmt
   - go test -v -race ./...                   # Run all the tests with the race detector enabled
   - go vet ./...                             # go vet is the official Go static analyzer
-  - megacheck ./...                          # "go vet on steroids" + linter
+#  - megacheck ./...                          # "go vet on steroids" + linter
 #  - gocyclo -over 19 $GO_FILES               # forbid code with huge functions

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Twitter](https://img.shields.io/badge/twitter-@Ice3man543-blue.svg)](https://twitter.com/Ice3man543)
 [![Twitter](https://img.shields.io/badge/twitter-@codingo__-blue.svg)](https://twitter.com/codingo_)
 [![Twitter](https://img.shields.io/badge/Twitter-Mzack9999-blue.svg)](https://twitter.com/Mzack9999)
+[![Build Status](https://travis-ci.org/subfinder/subfinder.svg?branch=master)](https://travis-ci.org/subfinder/subfinder)
 [![Go Report Card](https://goreportcard.com/badge/github.com/subfinder/subfinder)](https://goreportcard.com/report/github.com/subfinder/subfinder) 
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/subfinder/subfinder/issues)
 


### PR DESCRIPTION
This reintroduces an automated test case to enforce linting over the code base.

This includes future tests for limiting large functions, however I've temporarily disabled this whilst @Mzack9999 fixes  the existing presence of this in the code base. These lines should be updated once t hat has been fixed:

```
#  - go get github.com/fzipp/gocyclo
```
And:
```
#  - gocyclo -over 19 $GO_FILES               # forbid code with huge functions
```
