### PR TITLE
Fixing resolver settings, and unexpected behavior

### DIFF
--- a/subf/subfinder.go
+++ b/subf/subfinder.go
@@ -161,8 +161,6 @@ func (s *Subfinder) setCommonResolver() {
 	s.State.LoadResolver = append(s.State.LoadResolver, "8.8.4.4")
 	s.State.LoadResolver = append(s.State.LoadResolver, "9.9.9.9")
 	s.State.LoadResolver = append(s.State.LoadResolver, "9.9.9.10")
-	s.State.LoadResolver = append(s.State.LoadResolver, "209.244.0.3")
-	s.State.LoadResolver = append(s.State.LoadResolver, "209.244.0.4")
 	s.State.LoadResolver = append(s.State.LoadResolver, "208.67.222.222")
 	s.State.LoadResolver = append(s.State.LoadResolver, "208.67.220.220")
 }

--- a/subf/subfinder.go
+++ b/subf/subfinder.go
@@ -151,7 +151,7 @@ func (s *Subfinder) parseBruteForce() {
 
 func (s *Subfinder) setCommonResolver() {
 	// Use the default resolvers
-	if s.State.ComResolver != "" && s.State.ListResolver != "" {
+	if s.State.ComResolver != "" || s.State.ListResolver != "" {
 		return
 	}
 


### PR DESCRIPTION
Heyo,

I was playing around with subfinder (installed via `go get`), and I noticed that non-resolvable subdomains were returning a phony ip address of `198.105.244.11`. This was weird, because I've successfully used the v1 release binary in the past.

It turns out `198.105.244.11` belongs to `Search Guide Inc` which is a dns hijacking service for advertisements. Apparently level3 is a shitty citizen of the internet, and they redirect non-resolvable requests to a third party advertising/searchengine service...

Therefore I propose we remove level3 from the default set of resolvers; as it breaks dns brute forcing by returning false-positives for every unresolvable subdomain.

---

Additionally I discovered the above side effect because subfinder was ignoring the resolver ip addresses I was passing in via `-r`/`-rL`. It looks to me as this was a simple copypasta typo that occurred during a recent refactor: https://github.com/subfinder/subfinder/commit/29b85aec89f2ec24feec39fd896a5d08e2482dfd#diff-7ddfb3e035b42cd70649cc33393fe32cL161

---

I've addressed both of these issues in two separate commits within this pull request. Please let me know if I need to change anything to get merged.


