### PR TITLE
subf: add go module support

### DIFF
--- a/subf/go.mod
+++ b/subf/go.mod
@@ -1,3 +1,3 @@
-module github.com/subfinder/subfinder/subf
+module github.com/hazcod/subfinder/subf
 
 go 1.12

--- a/subf/go.mod
+++ b/subf/go.mod
@@ -1,0 +1,3 @@
+module github.com/subfinder/subfinder/subf
+
+go 1.12


### PR DESCRIPTION
This will allow others to use `github.com/subfinder/subfinder/subf` as a Go module dependency, which will be enabled by default in Go 1.13.