### PR TITLE
Fixing "net/url: invalid control character in URL" error on waybackarchive

### DIFF
--- a/libsubfinder/sources/waybackarchive/waybackarchive.go
+++ b/libsubfinder/sources/waybackarchive/waybackarchive.go
@@ -51,7 +51,7 @@ func Query(args ...interface{}) interface{} {
 	}
 
 	for i := 0; i <= numPages; i++ {
-		resp, err := helper.GetHTTPResponse("http://web.archive.org/cdx/search/cdx?url=*."+domain+"/*&output=json&fl=original&collapse=urlkey&page="+string(i), state.Timeout)
+		resp, err := helper.GetHTTPResponse("http://web.archive.org/cdx/search/cdx?url=*."+domain+"/*&output=json&fl=original&collapse=urlkey&page="+strconv.Itoa(i), state.Timeout)
 		if err != nil {
 			if !state.Silent {
 				fmt.Printf("\nwaybackarchive: %v\n", err)


### PR DESCRIPTION
Running string() on an integer returns an empty string, changing to strconv.Itoa() instead.

See example: 
```golang
package main

import (
	"fmt"
	"strconv"
)

func main() {
	i := 0
	fmt.Printf("i='%d'\n", i)
	fmt.Printf("i='%s'\n", string(i))
	fmt.Printf("i='%s'\n", strconv.Itoa(i))
}
```
```$ go run test.go
i='0'
i=''
i='0'
```